### PR TITLE
Support for writing files to disk

### DIFF
--- a/system/VBA/lbsHelper.txt
+++ b/system/VBA/lbsHelper.txt
@@ -188,6 +188,32 @@ ErrorHandler:
     loadFromREST = ""
 End Function
 
+Private Function DecodeBase64(ByVal strData As String) As Byte()
+    Dim objXML As Object
+    Dim objNode As Object
+    
+    Set objXML = CreateObject("MSXML2.DOMDocument")
+    Set objNode = objXML.createElement("b64")
+    objNode.DataType = "bin.base64"
+    objNode.Text = strData
+    DecodeBase64 = objNode.nodeTypedValue
+    
+    Set objNode = Nothing
+    Set objXML = Nothing
+End Function
+
+Public Sub saveFile(FilePath As String, Content As String)
+    Dim file As String
+    Dim toWrite As String
+    Dim fnum1 As Variant
+    toWrite = StrConv(DecodeBase64(Content), vbUnicode)
+    file = WebFolder & FilePath
+    fnum1 = FreeFile()
+    Open file For Output As #fnum1
+    Print #fnum1, toWrite
+    Close #fnum1
+End Sub
+
 '=============================================
 ' Load XML from SOAP webservice
 '=============================================

--- a/system/js/lbs.common.js
+++ b/system/js/lbs.common.js
@@ -67,12 +67,15 @@ lbs.common = {
     /**
     * Helperfunction to run VBA functions from JS
     */
-    "executeVba": function (inString) {
+    "executeVba": function (inString, params) {
         try {
             lbs.log.debug("Trying to execute VBA:" + inString);
             var vbaline;
 
             var inArgs = inString.split(',');
+            if(params){
+                inArgs = inArgs.concat(params);
+            }
 
             if (inArgs.length > 1) {
 

--- a/system/js/lbs.loader.js
+++ b/system/js/lbs.loader.js
@@ -359,6 +359,9 @@ lbs.loader = {
         return lbs.common.executeVba("lbsHelper.loadHTTPResource," + path  );
     },
 
+    "saveLocalFile" : function(path, text) {
+        lbs.common.executeVba("lbsHelper.saveFile," + path, [text])
+    },
 
     /**
     Only return unique values


### PR DESCRIPTION
Support for writing files to disk, file content should be base64 encoded to avoid problems with use of '," or other reserved chars

Example use: `lbs.loader.saveLocalFile("filename", btoa("some data"));`
