### PR TITLE
Support for loading resources async, requires wiring in viewmodel before use

### DIFF
--- a/system/js/lbs.loader.js
+++ b/system/js/lbs.loader.js
@@ -314,6 +314,19 @@ lbs.loader = {
                         lbs.log.warn("Failed to load datasource: " + dataSource.type + ':' + dataSource.source,e)
                     }
                     break;
+                case 'AsyncPost':
+                    var params = dataSource.parameters || {};
+                    $.support.cors = true;
+                    data = {};
+                    data[dataSource.alias] = $.ajax({
+                        contentType: 'application/json',
+                        data: JSON.stringify(params),
+                        dataType: 'json',
+                        type: 'POST',
+                        url: dataSource.url,
+                        crossDomain: true
+                    });
+                    break;
             }
 
             //merge options into the viewModel


### PR DESCRIPTION
Support for async invoking of a datasource for use with [Lime.Proxy](https://github.com/FredrikL/Lime.Proxy) or other CORS aware service. Currently only a POST http request will be made.

Datasource defenition:            

``` Javascript
{ type:'AsyncPost', alias: "table",
  url: "http://localhost:8000/v1/some_db/table/some_Table", 
  parameters: { Fields: ["name"], Conditions: [] }}
```

Alias and url **MUST** be supplied.

This will create 2 properties on viewModel that are [jQuery promises](https://api.jquery.com/promise/), to use data add a done handler.
Example:

``` Javascript
this.initialize = function (node,viewModel) {
    viewModel.coworker = ko.observable("");

    viewModel.table.done(function(data) {
        var d = JSON.parse(data);
        viewModel.coworker(d["some_Table"]["@name"]);
    });

    return viewModel;
}
```

property used on vm needs to be declared before done function has run, for fast queries the result may be available before initialize is called.
