### PR TITLE
Added support for 'activeuser'

### DIFF
--- a/system/js/lbs.loader.js
+++ b/system/js/lbs.loader.js
@@ -365,6 +365,20 @@ lbs.loader = {
                         crossDomain: true
                     });
                     break;
+            	case 'activeuser':
+                    try{
+                        var activeuser = lbs.limeDataConnection.ActiveUser.record
+                        data = lbs.loader.recordToJSON(activeuser, 'activeuser');
+                        if (!activeuser){
+                            lbs.log.warn("Failed to load the activeuser");
+                        }
+                        else if(!activeuser.Record){
+                            lbs.log.warn("Active user does not have a coworker card.");
+                        }
+                    }
+                    catch (ex) {
+                        lbs.log.warn("Failed to load activeuser.");
+                    }
             }
 
             //merge options into the viewModel


### PR DESCRIPTION
It will be possible to add activeuser as a datasource. The change uses lbs.limeDataconnection.ActiveUser.Record.
this will get the activeusers Record and make it available in the Viewmodel. Making it possible to compare an inspectors values against the coworker card of the actively logged in user.

The change will warn to the log if the activeuser record is missing. Tested briefly.
how to test:
Add datasource ```{type:'activeuser'} ```
add ```<div data-bind="text:activeuser.name.text"></div>``` in the corresponding actionpad.