### PR TITLE
Fix so trailing slash isn't added when params

### DIFF
--- a/src/lib/dataSources/lbs.dataSource.customEndpoint.js
+++ b/src/lib/dataSources/lbs.dataSource.customEndpoint.js
@@ -13,7 +13,7 @@ export default class CustomEndpoint extends dataSource {
         if (this.relativeUrl.charAt(0) !== '/') { // Prepend slash
             url = `/${url}`
         }
-        if (this.relativeUrl.charAt(this.relativeUrl.length - 1) !== '/') { // Append slash
+        if (this.relativeUrl.charAt(this.relativeUrl.length - 1) !== '/' && !url.indexOf('?')) { // Append slash
             url = `${url}/`
         }
         if (this.params) {


### PR DESCRIPTION
When using custom endpoint as source with params a slash will break the url. This is a quick-fix for that.